### PR TITLE
ci: add github actions for pull requests automated checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+---
+name: CI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build binaries
+      run: cargo build
+    - name: Run tests
+      run: cargo test
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check code format
+        run: cargo fmt --all -- --check
+  
+  clippy:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint code
+        run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,14 @@
+---
+name: Pull Request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Leetcode Command Line Interface
 
+[![Tests Status][actions-badge]][actions-url]
+
+[actions-badge]: https://github.com/coding-kelps/leetcode-cli/actions/workflows/ci.yaml/badge.svg?branch=main
+
 Interact with LeetCode in your development environment.
 
 ## Example


### PR DESCRIPTION
This PR add two basic GitHub Actions to make small CI automations:
- CI: proceed to some automated checks when called (can only be called manually or by other GitHub Actions).
- PR: triggered when a Pull Request is made or edited it trigger the CI GitHub Action

#### Side-Notes
I've also added a badge on the README.md to indicate the current CI status of the main branch.