### PR TITLE
docs: add cargo package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,18 @@
 [package]
-name = "leetcode_cli"
+name = "leetcode-cli"
 version = "0.1.0"
+authors = ["Coding Kelps"]
+autotests = false
+categories = ["command-line-utilities"]
+description = "Interact with LeetCode in your development environment."
 edition = "2021"
+exclude = []
+homepage = "https://github.com/coding-kelps/leetcode-cli"
+keywords = ["leetcode"]
+license = "GPL-3.0"
+readme = "README.md"
+repository = "https://github.com/coding-kelps/leetcode-cli"
+rust-version = "1.83"
 
 [dependencies]
 leetcoderustapi = "1.0.8"
@@ -16,4 +27,3 @@ warp = "0.3.7"
 colored = "3.0.0"
 nanohtml2text = "0.2.1"
 html2md = "0.2.15"
-

--- a/EMBRYO.md
+++ b/EMBRYO.md
@@ -1,18 +1,21 @@
-**1. What is the project’s objective?**
+# Embryo
+The Embryo manifest outlines the initial vision and objectives of an experimental project by answering a few questions.
+
+## What is the project’s objective?
 
 _Clearly define the purpose and utility of the project._
 → Summarize in one sentence what the project is supposed to do.
 
 Interact with leetcode in your terminal (get info / code, submit problem for any language) and get info on your profile.
 
-**2. What value does it bring?**
+## What value does it bring?
 
 _Why is this project worth developing or using?_
 → Explain what users (or yourself) will gain or learn from this project.
 
 leetcode code interface doesn't support a fully integrated IDE experience yet, so it's a little painful to write code there. allow to bring a problem down to a local environment.
 
-**3. What are the completion criteria?**
+## What are the completion criteria?**
 _When is the project considered at a major milestone?_
 → Define milestones or issues that help measure progress.
 


### PR DESCRIPTION
I added some metadata to the Cargo.toml of the project, I didn't filled the "authors" attribute as I didn't knew how @dfayd0 wanted to define it.

I've also standardized the EMBRYO.md (changed name to english, added a small description).